### PR TITLE
Apply upstream (rest-server) API changes

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -16,12 +16,14 @@ func init() {
 func setup(c *caddy.Controller) error {
 	var basePath string
 
+	restConfig := restserver.Server{}
+
 	for c.Next() {
 		if c.NextArg() {
 			basePath = c.Val()
 		}
 		if c.NextArg() {
-			restserver.Config.Path = c.Val()
+			restConfig.Path = c.Val()
 		}
 		if c.NextArg() {
 			return c.ArgErr()
@@ -32,15 +34,15 @@ func setup(c *caddy.Controller) error {
 		basePath = "/"
 	}
 
-	cfg := httpserver.GetConfig(c)
+	httpConfig := httpserver.GetConfig(c)
 	mid := func(next httpserver.Handler) httpserver.Handler {
 		return ResticHandler{
 			Next:          next,
 			BasePath:      basePath,
-			RestServerMux: restserver.NewMux(),
+			RestServerMux: restserver.NewHandler(restConfig),
 		}
 	}
-	cfg.AddMiddleware(mid)
+	httpConfig.AddMiddleware(mid)
 
 	return nil
 }


### PR DESCRIPTION
In June 2018, dependency [rest-server](https://github.com/restic/rest-server) cleaned up [its API a little](https://github.com/restic/rest-server/pull/67), breaking the restic Caddy plugin build in the process.

Since then, attempting to build the restic Caddy plugin produces the following errors:

```
build/src/github.com/restic/caddy/setup.go:24:4: undefined: restserver.Config
build/src/github.com/restic/caddy/setup.go:40:19: undefined: restserver.NewMux
```

This PR applies the upstream API changes to fix the errors.

**Note:** This is a best-effort fix. I don’t even use restic, and saw the build error by pure coincidence because I happened to include the plugin accidentally. This fix is therefore completely untested.
**If possible, please test before merging.**
