### PR TITLE
Fix #10 Correct module path to match repository.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tdralle/caddy
+module github.com/restic/caddy
 
 go 1.22.0
 


### PR DESCRIPTION
As stated in #10 the current module path prevents `xcaddy build` from working with this plugin.

This PR contains the proposed fix.